### PR TITLE
Add lookup functionality for countries and organization types

### DIFF
--- a/src/main/java/com/froilan/synectix/config/security/SecurityConfig.java
+++ b/src/main/java/com/froilan/synectix/config/security/SecurityConfig.java
@@ -26,7 +26,10 @@ public class SecurityConfig {
                 .rememberMe(AbstractHttpConfigurer::disable).httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .oauth2ResourceServer(
-                        oauth2 -> oauth2.jwt(withDefaults()));
+                        oauth2 -> oauth2.jwt(withDefaults()))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/lookup/**").permitAll()
+                        .anyRequest().authenticated());
         return http.getOrBuild();
     }
 

--- a/src/main/java/com/froilan/synectix/controller/lookup/LookupController.java
+++ b/src/main/java/com/froilan/synectix/controller/lookup/LookupController.java
@@ -1,0 +1,40 @@
+package com.froilan.synectix.controller.lookup;
+
+import java.time.LocalDateTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.froilan.synectix.util.RequestLogger;
+import com.froilan.synectix.util.security.GetClientIP;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.http.HttpStatus;
+
+@RestController
+@RequestMapping("/api/lookup")
+public class LookupController {
+    private static final Logger logger = LoggerFactory.getLogger(RequestLogger.class);
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/countries")
+    public String getMethodName(HttpServletRequest request) {
+        logger.info(LocalDateTime.now().toString(),
+                " - Sign in request for user: {}" + GetClientIP.extractClientIp(request));
+        return new String();
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/organization-types")
+    public String getOrganizationTypes(HttpServletRequest request) {
+        logger.info(LocalDateTime.now().toString(),
+                " - Sign in request for user: {}" + GetClientIP.extractClientIp(request));
+        return new String();
+    }
+
+}

--- a/src/main/java/com/froilan/synectix/controller/lookup/LookupController.java
+++ b/src/main/java/com/froilan/synectix/controller/lookup/LookupController.java
@@ -1,6 +1,7 @@
 package com.froilan.synectix.controller.lookup;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,6 +9,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.froilan.synectix.model.lookup.Country;
+import com.froilan.synectix.model.lookup.OrganizationType;
+import com.froilan.synectix.service.lookup.LookupService;
 import com.froilan.synectix.util.RequestLogger;
 import com.froilan.synectix.util.security.GetClientIP;
 
@@ -15,26 +19,32 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @RestController
 @RequestMapping("/api/lookup")
 public class LookupController {
     private static final Logger logger = LoggerFactory.getLogger(RequestLogger.class);
+    private final LookupService lookupService;
+
+    public LookupController(LookupService lookupService) {
+        this.lookupService = lookupService;
+    }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/countries")
-    public String getMethodName(HttpServletRequest request) {
+    public List<Country> getMethodName(HttpServletRequest request) {
         logger.info(LocalDateTime.now().toString(),
-                " - Sign in request for user: {}" + GetClientIP.extractClientIp(request));
-        return new String();
+                " - Lookup request from IP: {}" + GetClientIP.extractClientIp(request));
+        return ResponseEntity.ok(lookupService.getAllCountries()).getBody();
     }
 
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/organization-types")
-    public String getOrganizationTypes(HttpServletRequest request) {
+    public List<OrganizationType> getOrganizationTypes(HttpServletRequest request) {
         logger.info(LocalDateTime.now().toString(),
-                " - Sign in request for user: {}" + GetClientIP.extractClientIp(request));
-        return new String();
+                " - Lookup request from IP: {}" + GetClientIP.extractClientIp(request));
+        return ResponseEntity.ok(lookupService.getAllOrganizationTypes()).getBody();
     }
 
 }

--- a/src/main/java/com/froilan/synectix/model/Company.java
+++ b/src/main/java/com/froilan/synectix/model/Company.java
@@ -80,7 +80,7 @@ public class Company {
     @Getter
     @Setter
     @ManyToOne
-    @JoinColumn(name = "country_id", nullable = false, table = "country", updatable = false)
+    @JoinColumn(name = "country_id", nullable = false, updatable = false)
     private Country country;
 
     /**

--- a/src/main/java/com/froilan/synectix/service/lookup/LookupService.java
+++ b/src/main/java/com/froilan/synectix/service/lookup/LookupService.java
@@ -1,0 +1,40 @@
+package com.froilan.synectix.service.lookup;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.froilan.synectix.model.lookup.Country;
+import com.froilan.synectix.model.lookup.OrganizationType;
+import com.froilan.synectix.repository.CountryRepository;
+import com.froilan.synectix.repository.OrganizationTypeRepository;
+
+@Service
+public class LookupService {
+    private final CountryRepository countryRepository;
+    private final OrganizationTypeRepository organizationTypeRepository;
+
+    public LookupService(CountryRepository countryRepository,
+            OrganizationTypeRepository organizationTypeRepository) {
+        this.countryRepository = countryRepository;
+        this.organizationTypeRepository = organizationTypeRepository;
+    }
+
+    /**
+     * Retrieves all countries from the repository.
+     *
+     * @return a list of all countries
+     */
+    public List<Country> getAllCountries() {
+        return countryRepository.findAll();
+    }
+
+    /**
+     * Retrieves all organization types from the repository.
+     *
+     * @return a list of all organization types
+     */
+    public List<OrganizationType> getAllOrganizationTypes() {
+        return organizationTypeRepository.findAll();
+    }
+}

--- a/src/main/java/com/froilan/synectix/util/security/GetClientIP.java
+++ b/src/main/java/com/froilan/synectix/util/security/GetClientIP.java
@@ -1,0 +1,24 @@
+package com.froilan.synectix.util.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class GetClientIP {
+    public static String extractClientIp(HttpServletRequest request) {
+        String[] headersToCheck = {
+                "X-Forwarded-For",
+                "Proxy-Client-IP",
+                "WL-Proxy-Client-IP",
+                "HTTP_CLIENT_IP",
+                "HTTP_X_FORWARDED_FOR"
+        };
+
+        for (String header : headersToCheck) {
+            String ipList = request.getHeader(header);
+            if (ipList != null && !ipList.isEmpty() && !"unknown".equalsIgnoreCase(ipList)) {
+                return ipList.split(",")[0].trim(); // In case of multiple IPs
+            }
+        }
+
+        return request.getRemoteAddr(); // Fallback
+    }
+}


### PR DESCRIPTION
Introduce a new LookupController and LookupService to handle lookup requests for countries and organization types. Update security configuration to allow public access to the lookup API while requiring authentication for other endpoints. Refactor the Company entity's country_id join column definition.